### PR TITLE
docs: migrate Flatbuffers documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ application messages trasmitted over WebSockets.
 Flatbuffers provides an efficient serialisation/deserialisaton mechanism in terms of both processing
 and space requirements.
 
-See our [Developer Docs](https://reactivemarkets.github.io/developer/) for full documentation.
+See our [Developer Docs](https://developer.reactivemarkets.com) for full documentation.
 
 ## Getting Started
 

--- a/flatbuffers/Enum.fbs
+++ b/flatbuffers/Enum.fbs
@@ -13,27 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 // {{namespace}}
 
-// An enumerated list of feed types, which may include different kinds of
-// aggregation, liquidity views, public trade feeds, trading signals, and other
-// analytics.
 enum FeedType: int16 {
     Default = 0,
     Trade = 1
 }
 
-// Buy or sell side of the market.
 enum Side: int8 {
     Sell = -1,
     None = 0,
     Buy = 1
 }
 
-// Subscription request type.
 enum SubReqType: int8 {
-    // Subscribe to one or more market feeds.
     Subscribe = 1,
-    // Unsubscribe from one or more market feeds.
     Unsubscribe
 }

--- a/flatbuffers/FeedRequest.fbs
+++ b/flatbuffers/FeedRequest.fbs
@@ -13,34 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 include "Enum.fbs";
 
 // {{namespace}}
 
-// The FeedRequest message represents a client request to either subscribe to or
-// unsubscribe from one or more market feeds.
 table FeedRequest {
-    // Request identifier assigned by the client.
-    // Only the first 48 characters are significant.
     req_id: string (id: 0);
-    // Subscription request type.
     sub_req_type: SubReqType = 1 (id: 1);
-    // Feed type.
     feed_type: FeedType (id: 2);
-    // The aggregation grouping granularity.
-    // This parameter is commonly used to describe the tick grouping at each
-    // level in the order book, but it may also be used for other purposes.
-    // This feature is only available on supported feeds.
     grouping: uint16 (id: 3);
-    // The desired number of levels in the market-data book.
-    // This feature is only available on supported feed-types.
-    // Currently supported values are: 1, 5 and 10.
-    // This feature is only available on supported feeds.
     depth: int16 (id: 4);
-    // The desired update frequency.
-    // The frequency need not be specified when unsubscribing.
-    // This feature is only available on supported feeds.
     frequency: int16 (id: 5);
-    // The set of markets to which the request applies.
     markets: [string] (id: 6);
 }

--- a/flatbuffers/FeedRequestAccept.fbs
+++ b/flatbuffers/FeedRequestAccept.fbs
@@ -13,16 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 include "Enum.fbs";
 
 // {{namespace}}
 
-// The FeedRequestAccept is sent by the server to acknowledge a successful
-// FeedRequest.
 table FeedRequestAccept {
-    // Request identifier assigned by the client.
-    // Only the first 48 characters are significant.
     req_id: string (id: 0);
-    // Feed identifier.
     feed_id: int32 (id: 1);
 }

--- a/flatbuffers/FeedRequestReject.fbs
+++ b/flatbuffers/FeedRequestReject.fbs
@@ -13,14 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 // {{namespace}}
 
-// The FeedRequestReject is sent by the server when a FeedRequest cannot be
-// satisfied for business, operational, or technical reasons.
 table FeedRequestReject {
     req_id: string (id: 0);
-    // Error code indicating the reject reason.
-    error_code: int (id: 1);
-    // Textual error message describing the reject reason.
+    error_code: int32 (id: 1);
     error_message: string (id: 2);
 }

--- a/flatbuffers/MDSnapshotL2.fbs
+++ b/flatbuffers/MDSnapshotL2.fbs
@@ -13,47 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 include "Enum.fbs";
 
 // {{namespace}}
 
-// MDLevel2 represents an entry in the level 2 order book. A level 2 order book
-// comprises one or more levels, where each level is aggregated either by price
-// or quantity, depending on the feed type.
 struct MDLevel2 {
     qty: float64;
     price: float64;
 }
 
-// The MDSnapshotL2 messages is sent by the server when there is a market-data
-// update.
 table MDSnapshotL2 {
-    // Source system timestamp as nanoseconds since Unix epoch.
-    // This timestamp may be zero when the book is cleared and the sequence
-    // reset to zero.
     source_ts: int64 (id: 0);
-    // Source system identifier.
     source: string (id: 1);
-    // Market symbol.
     market: string (id: 2, required);
-    // Feed identifier.
     feed_id: int32 (id: 3);
-    // A marker-specific identifier that uniquely identifies this update.
-    // The identifier may be periodically reset by the source system. Clients
-    // should treat this as an opaque identifier and should not attempt to infer
-    // meaning from its content.
-    // Zero is reserved as a special case for clearing or resetting the book.
-    // This feature is only available on supported feed-types.
     id: int64 (id: 4);
-    // The desired number of levels in the market-data book.
-    // This feature is only available on supported feed-types.
-    // Currently supported values are: 1, 5 and 10.
-    // This feature is only available on supported feeds.
     depth: int16 (id: 5);
-    // Bitset describing the attributes of the market or update.
     flags: uint16 = 0 (id: 6);
-    // Level-2 bid data.
     bid_side: [MDLevel2] (id: 7);
-    // Level-2 offer data.
     offer_side: [MDLevel2] (id: 8);
 }

--- a/flatbuffers/Message.fbs
+++ b/flatbuffers/Message.fbs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 include "FeedRequest.fbs";
 include "FeedRequestAccept.fbs";
 include "FeedRequestReject.fbs";
@@ -36,10 +38,7 @@ union Body {
 }
 
 table Message {
-    // Transmission timestamp. This is the time that the message was sent from
-    // the gateway as nanoseconds since Unix epoch.
-    tts: long (id: 0);
-    // Message body.
+    tts: int64 (id: 0);
     body: Body (id: 2);
 }
 

--- a/flatbuffers/PublicTrade.fbs
+++ b/flatbuffers/PublicTrade.fbs
@@ -13,35 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 include "Enum.fbs";
 
 // {{namespace}}
 
-// Public trade information.
 table PublicTrade {
-    // Source system timestamp as nanoseconds since Unix epoch.
     source_ts: int64 (id: 0);
-    // Source system identifier.
     source: string (id: 1);
-    // Market symbol.
     market: string (id: 2, required);
-    // Feed identifier.
     feed_id: int32 (id: 3);
-    // Optional identifier or sequence number assigned by the execution venue.
     trade_id: string (id: 4);
-    // Bitset describing the attributes of the market or update.
     flags: uint16 = 0 (id: 5);
-    // Trade direction. This field is always from the taker's perspective:
-    // - Buy: aggressor/taker bought;
-    // - Sell: aggressor/taker sold.
-    // The quantiy may be zero (None) if the underlying execution venue does not
-    // publish this information.
     side: Side (id: 6);
-    // Trade quantity. The quantiy may be zero if the underlying execution venue does not
-    // publish this information.
     qty: float64 (id: 7);
-    // Trade price.
     price: float64 (id: 8);
-    // Underyling execution venue.
     exec_venue: string (id: 9);
 }

--- a/flatbuffers/SessionStatus.fbs
+++ b/flatbuffers/SessionStatus.fbs
@@ -13,17 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://developer.reactivemarkets.com/api for documentation.
+
 // {{namespace}}
 
-// Pricing or trading session status. This is a system wide status that applies
-// to all feeds and markets provided by the source system.
 table SessionStatus {
-    // Source system timestamp as nanoseconds since Unix epoch.
     source_ts: int64 (id: 0);
-    // Source system identifier.
     source: string (id: 1);
-    // Status code.
-    code: int (id: 2);
-    // Detailed status message.
+    code: int32 (id: 2);
     message: string (id: 3);
 }


### PR DESCRIPTION
The Flatbuffers API documentation has been migrated to:
https://developer.reactivemarkets.com/api
So the documentation in the schema files is now redundant.

DEV-2113