### PR TITLE
DEV-2117: Maven pom.xml has variable reference

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,16 +29,18 @@ jobs:
 
     steps:
       - name: Checkout the code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:
           java-version: 8
 
-      - name: Set release version
+      - name: Set Maven POM version
         run: |
-          echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF##*/} | sed "s,^v,,")
+          version=$(echo ${GITHUB_REF##*/} | sed "s,^v,,")
+          echo "version: $version"
+          mvn -q versions:set "-DnewVersion=$version"
 
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.reactivemarkets</groupId>
   <artifactId>papi</artifactId>
-  <version>${env.RELEASE_VERSION}</version>
+  <version>0.0.1</version>
   <packaging>jar</packaging>
 
   <name>Platform API for Java</name>


### PR DESCRIPTION
The `env.RELEASE_VERSION` reference still exists in the uploaded artefact:
https://search.maven.org/artifact/com.reactivemarkets/papi/0.8.0/jar

DEV-2117