### PR TITLE
DEV-2199: solve backward compatibility

### DIFF
--- a/flatbuffers/Message.fbs
+++ b/flatbuffers/Message.fbs
@@ -33,10 +33,10 @@ union Body {
     FeedRequest,
     FeedRequestAccept,
     FeedRequestReject,
-    LiquidationOrder,
     MDSnapshotL2,
     PublicTrade,
-    SessionStatus
+    SessionStatus,
+    LiquidationOrder
 }
 
 table Message {


### PR DESCRIPTION
Solve backward compatibility issue, which allows old version
v0.9.0 still works for new feedgw.

DEV-2199